### PR TITLE
fix broken links on site

### DIFF
--- a/src/site-menu/index.js
+++ b/src/site-menu/index.js
@@ -99,7 +99,13 @@ class SiteMenu extends HTMLElement {
     }
   };
 
+  menuIsOpen = () => {
+    return this.burgerEl.getAttribute('aria-expanded') === 'true' || false;
+  };
+
   closemenu = event => {
+    if (!this.menuIsOpen()) return;
+
     // Clicks inside menu should not close menu -->
     // Only proceed if event target is not inside menuContent
     if (this.menuContent.contains(event.target)) return;


### PR DESCRIPTION
Adding the closemenu function to an eventhandler on document required an extra check. Without it nothing was clickable outside the menu.