### PR TITLE
fix: typo for alt text on image made it overwrite src

### DIFF
--- a/src/image-block/index.js
+++ b/src/image-block/index.js
@@ -45,7 +45,7 @@ class MilesImageBlock extends HTMLElement {
   attributeChangedCallback(name, oldValue, newValue) {
     if (name === 'alt') {
       if (newValue) {
-        this.image.setAttribute('src', newValue);
+        this.image.setAttribute('alt', newValue);
       }
     }
 


### PR DESCRIPTION
I found a smal typo 