### PR TITLE
#93 Allow content on the right side of the miles banner

### DIFF
--- a/src/banner/banner.stories.js
+++ b/src/banner/banner.stories.js
@@ -20,3 +20,20 @@ export const Banner = {
     icon: 'miles-curve',
   },
 };
+
+export const BannerWithContentOnRightSide = {
+  args: {
+    title: 'Welcome to our website!',
+    variant: 'split',
+    reverse: false,
+    icon: 'miles-curve',
+  },
+  render: args => {
+    return `<miles-banner ${propsToAttrs(args)}>
+      <p>Now supporting <strong>bold</strong>, <em>italic</em>, <span style="background:#004047;color:#fff;">colours</span> and other HTML tags</p>
+      <div slot="right__banner__content" style="background-color: #450d21; height: 100%; display: flex; align-items: center; justify-content: center;">
+        <p style="color: white;">I'm on the right side</p>
+      </div>
+    </miles-banner>`
+  }
+};

--- a/src/banner/index.js
+++ b/src/banner/index.js
@@ -20,7 +20,10 @@ template.innerHTML = `
               </div>
           </div>
 		</div>
-		<div part="banner-image" class="banner__image"></div>
+		<div part="banner-image" class="banner__image">
+      <slot name="right__banner__content">
+      </slot>
+    </div>
 	</div>
 `;
 
@@ -38,20 +41,6 @@ class MilesBanner extends HTMLElement {
 
   static get observedAttributes() {
     return ['image', 'title', 'variant', 'reverse', 'icon'];
-  }
-
-  connectedCallback() {
-    const container = this.shadowRoot.querySelector('.banner__inner');
-    const children = this.childNodes;
-    if (children.length > 0 && container) {
-      while (container.firstChild) {
-        container.removeChild(container.firstChild);
-      }
-
-      for (let i = 0; i < children.length; i++) {
-        container.appendChild(children[i].cloneNode(true));
-      }
-    }
   }
 
   attributeChangedCallback(name, oldValue, newValue) {


### PR DESCRIPTION
This PR enables us to add content on the right side of the miles banner. More specifically, it allows us to use SVGs on the logo page rather than raster graphics that doesn't scale well to different screen resolutions. To add markup to the right side, simply add an element with a `slot="right__banner__content"` attribute. That element will then by copied into the named slot in the _miles-banner_ web component.

```html
<!-- wp:miles-blocks/miles-banner {"variant":"split","title":"Miles logo"} -->
<div slot="right__banner__content">
<p>Whatever goes in here is displayed on the right side of the banner</p>
</div>
<!-- /wp:miles-blocks/miles-banner -->
```

I simply removed the connectedCallback which manually copies content within the <miles-banner> block into the slot as this should already be handled by the built-in mechanism of web components. 

Please note that this change is accompanied with a necessary change in the web-components-plugin-repo. These changes are already committed and no further action is required. 

Resolves #93 

