### PR TITLE
#96 fix storybok build action

### DIFF
--- a/src/author-card/author-card.stories.js
+++ b/src/author-card/author-card.stories.js
@@ -1,4 +1,5 @@
 import { propsToAttrs } from '../storybook.utils.js';
+const BASE_URL = import.meta.env.VITE_BASE_URL;
 
 export default {
   title: 'Miles/Components/Cards/Author',
@@ -23,8 +24,6 @@ export const Card = {
     phone: '917 12 345',
     variant: 'wide',
     jobtitle: 'tjener',
-    image: `${
-      import.meta.env.VITE_BASE_URL
-    }wp-content/uploads/2019/06/miles_smile.png`,
+    image: `${BASE_URL}wp-content/uploads/2019/06/miles_smile.png`,
   },
 };

--- a/src/blogg-card/blogg-card.stories.js
+++ b/src/blogg-card/blogg-card.stories.js
@@ -1,5 +1,7 @@
 import { propsToAttrs } from '../storybook.utils.js';
 
+const BASE_URL = import.meta.env.VITE_BASE_URL;
+
 export default {
   title: 'Miles/Components/Cards/Blog',
   tags: ['autodocs'],
@@ -14,9 +16,7 @@ export const BloggCard = {
   args: {
     title: 'Smidig samspill: Hvordan IT-prosjektledelse og endri(...)',
     author: 'Ida Severinsen',
-    image: `${
-      import.meta.env.VITE_BASE_URL
-    }wp-content/uploads/2023/06/Kopi-av-_D__0061-1080x721.jpg`,
+    image: `${BASE_URL}wp-content/uploads/2023/06/Kopi-av-_D__0061-1080x721.jpg`,
     posted: '12/12/2022',
     url: 'https://www.vg.no',
     id: 'post-9903',

--- a/src/button/button.stories.js
+++ b/src/button/button.stories.js
@@ -1,6 +1,7 @@
 import { propsToAttrs } from '../storybook.utils.js';
 import { withActions } from '@storybook/addon-actions/decorator';
 import '../button/index.js';
+const BASE_URL = import.meta.env.VITE_BASE_URL;
 
 export default {
   title: 'Miles/Components',
@@ -36,7 +37,7 @@ export default {
 
 export const Button = {
   args: {
-    value: `${import.meta.env.VITE_BASE_URL}vi-er-miles/`,
+    value: `${BASE_URL}vi-er-miles/`,
     name: 'button-1',
     variant: 'primary',
   },

--- a/src/fagblogg-teaser/index.js
+++ b/src/fagblogg-teaser/index.js
@@ -1,5 +1,6 @@
 import styles from './fagblogg-teaser.css?inline';
 import cssVariables from '../styles/variables.css?inline';
+const BASE_URL = import.meta.env.VITE_BASE_URL;
 
 /**
   Miles Fagblogg teaser
@@ -54,7 +55,7 @@ class MilesFagbloggTeaser extends HTMLElement {
 
     this.shadowRoot
       .querySelector('miles-info')
-      .setAttribute('link', import.meta.env.VITE_BASE_URL);
+      .setAttribute('link', BASE_URL);
   }
 
   disconnectedCallback() {}

--- a/src/podcast-teaser/index.js
+++ b/src/podcast-teaser/index.js
@@ -1,5 +1,6 @@
 import styles from './podcast-teaser.css?inline';
 import cssVariables from '../styles/variables.css?inline';
+const BASE_URL = import.meta.env.VITE_BASE_URL;
 
 /**
  * Miles Podcast teaser
@@ -48,10 +49,10 @@ class MilesPodcastTeaser extends HTMLElement {
   connectedCallback() {
     this.shadowRoot
       .querySelector('miles-info')
-      .setAttribute('link', `${import.meta.env.VITE_BASE_URL}milespodden`);
+      .setAttribute('link', `${BASE_URL}milespodden`);
     this.shadowRoot
       .querySelector('a')
-      .setAttribute('href', `${import.meta.env.VITE_BASE_URL}milespodden`);
+      .setAttribute('href', `${BASE_URL}milespodden`);
   }
 
   static get observedAttributes() {


### PR DESCRIPTION
Rollups seems to have an issue with the usage of import statements directly in template literals. Rather than referencing the BASE_URL env directly, creating a top-level constant seems to have fixed the problem. 