### PR TITLE
Added option to remove img loading attribute.

### DIFF
--- a/src/profile-card/index.js
+++ b/src/profile-card/index.js
@@ -43,7 +43,7 @@ class MilesProfileCard extends HTMLElement {
   }
 
   static get observedAttributes() {
-    return ['image', 'name', 'jobtitle', 'location'];
+    return ['image', 'name', 'jobtitle', 'location', 'preloadimage'];
   }
 
   attributeChangedCallback(name, oldValue, newValue) {
@@ -68,6 +68,10 @@ class MilesProfileCard extends HTMLElement {
     if (name === 'name') {
       this.profileImageEl.setAttribute('alt', newValue);
       this.consultantNameEl.textContent = newValue;
+    }
+
+    if (name === 'preloadimage') {
+      this.profileImageEl.removeAttribute('loading');
     }
   }
 


### PR DESCRIPTION
Part of fix for https://github.com/miles-no/miles_no/issues/21
- The `loading` of an `img` tag is set to `eager` when not present